### PR TITLE
Replace ContainsDelimitedSubstrings with string.Contains

### DIFF
--- a/src/lib/WCountLib/Detectors/WordDetector.cs
+++ b/src/lib/WCountLib/Detectors/WordDetector.cs
@@ -51,7 +51,7 @@ public class WordDetector : IWordDetector
         if (separatorCount == input.Length || specialCharCount == input.Length)
             return false;
 
-        if (countStringsWithSpacesAsWords && input.ContainsDelimitedSubstrings(' ') && charValidity)
+        if (countStringsWithSpacesAsWords && input.Contains(' ') && charValidity)
             return true;
 
         return charValidity;


### PR DESCRIPTION
## Why

DotExtensions' `ContainsDelimitedSubstrings(' ')` can be replaced with the built-in `string.Contains(' ')` in `WordDetector.IsStringAWord`. The preceding validation (non-empty check, separator/punctuation length checks) guarantees that if a space exists, there is at least one non-space character present -- making the two calls functionally equivalent in this context.

## What changed

- `src/lib/WCountLib/Detectors/WordDetector.cs` line 54: replaced `input.ContainsDelimitedSubstrings(' ')` with `input.Contains(' ')`

This makes the `string` overload consistent with the `char[]` and `IEnumerable<char>` overloads, which already use native LINQ (`source.Any(c => c == ' ')` and a `containsSpace` flag respectively).

## Notes

- Build passes with 0 errors
- DotExtensions is still a dependency (used for `CharacterConstants.EscapeCharacters` in tests and `ThrowIfNullOrEmpty` on `StringSegment`); full removal is a separate effort

---

Co-authored-by: GitHub Copilot App (MiMo V2.5)