### PR TITLE
Remove DotExtensions NuGet dependency

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
-    <PackageVersion Include="DotExtensions" Version="10.5.0" />
     <PackageVersion Include="EnhancedLinq" Version="1.0.1" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="ThisAssembly.AssemblyInfo" Version="2.1.2" />

--- a/src/lib/WCountLib/Detectors/Segments/SegmentWordDetector.cs
+++ b/src/lib/WCountLib/Detectors/Segments/SegmentWordDetector.cs
@@ -8,7 +8,6 @@
  */
 
 using System.Linq;
-using DotExtensions.MsExtensions.Exceptions;
 using EnhancedLinq.MsExtensions.Deferred;
 
 namespace WCountLib.Detectors.Segments;
@@ -26,10 +25,10 @@ public class SegmentWordDetector : ISegmentWordDetector
     /// <returns>True if the string segment represents a single word, false otherwise.</returns>
     public bool IsSegmentAWord(StringSegment segment, bool countStringsWithSpacesAsWords = false)
     {
-        ArgumentException.ThrowIfNullOrEmpty(segment);
+        ArgumentException.ThrowIfNullOrEmpty(segment.Value);
         
         if (segment.Length == 1)
-            return !char.IsSpecialCharacter(segment[0]);
+            return !segment[0].IsSpecialCharacter();
         
         int regularChars = 0;
         int separatorCount = 0;
@@ -71,7 +70,7 @@ public class SegmentWordDetector : ISegmentWordDetector
     public bool DoesSegmentContainWords(StringSegment segment, char wordSeparator, 
         bool countSegmentsWithSpacesAsWords = false)
     {
-        ArgumentException.ThrowIfNullOrEmpty(segment);
+        ArgumentException.ThrowIfNullOrEmpty(segment.Value);
         
         IEnumerable<StringSegment> possibleWords = segment.SplitBy(wordSeparator);
         

--- a/src/lib/WCountLib/Detectors/WordDetector.cs
+++ b/src/lib/WCountLib/Detectors/WordDetector.cs
@@ -12,6 +12,18 @@ using System.Linq;
 namespace WCountLib.Detectors;
 
 /// <summary>
+/// Checks whether a character is a special (non-alphanumeric, non-whitespace) character.
+/// </summary>
+internal static class CharExtensions
+{
+    /// <summary>
+    /// Returns true if the character is a special character (punctuation or symbol).
+    /// </summary>
+    internal static bool IsSpecialCharacter(this char c) =>
+        char.IsPunctuation(c) || char.IsSymbol(c);
+}
+
+/// <summary>
 /// A class to detect if strings that look like words are words.
 /// </summary>
 public class WordDetector : IWordDetector
@@ -28,7 +40,7 @@ public class WordDetector : IWordDetector
         ArgumentException.ThrowIfNullOrEmpty(input);
         
         if (input.Length == 1)
-            return !char.IsSpecialCharacter(input[0]);
+            return !input[0].IsSpecialCharacter();
 
         int separatorCount = 0;
         int specialCharCount = 0;
@@ -64,7 +76,7 @@ public class WordDetector : IWordDetector
         if (source is IList<char> list)
         {
             if (list.Count == 1)
-                return !char.IsSpecialCharacter(list[0]);
+                return !list[0].IsSpecialCharacter();
         }
         
         int separatorCount = 0;
@@ -101,7 +113,7 @@ public class WordDetector : IWordDetector
         }
         
         if (count == 1)
-            return !char.IsSpecialCharacter(firstChar);
+            return !firstChar.IsSpecialCharacter();
 
         
         if (separatorCount == count || specialCharCount == count)
@@ -125,7 +137,7 @@ public class WordDetector : IWordDetector
         ArgumentNullException.ThrowIfNull(source);
         
         if (source.Length == 1)
-            return !char.IsSpecialCharacter(source[0]);
+            return !source[0].IsSpecialCharacter();
 
         int separatorCount = 0;
         int specialCharCount = 0;

--- a/src/lib/WCountLib/GlobalUsings.cs
+++ b/src/lib/WCountLib/GlobalUsings.cs
@@ -6,7 +6,6 @@ global using System.Collections.Generic;
 global using System.Text;
 global using System.Threading;
 global using System.Threading.Tasks;
-global using DotExtensions.Strings;
 global using Microsoft.Extensions.Primitives;
 global using WCountLib.Abstractions.Counters;
 global using WCountLib.Abstractions.Counters.Segments;

--- a/src/lib/WCountLib/WCountLib.csproj
+++ b/src/lib/WCountLib/WCountLib.csproj
@@ -14,8 +14,7 @@
         <RepositoryUrl>https://github.com/alastairlundy/WCount</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <EmbedUntrackedSources>true</EmbedUntrackedSources>
-        <PackageReleaseNotes>*Updated DotExtensions dependency from 6.3.0 to 7.2.0
-* Updated Polyfill to 8.0.1 from 7.24.0 and mark as an internal dependency with private assets
+        <PackageReleaseNotes>* Updated Polyfill to 8.0.1 from 7.24.0 and mark as an internal dependency with private assets
 * Updated Microsoft.Extensions.Primitives to 9.0.6
 * Updated WCountLib.Abstractions to 3.2.2.1</PackageReleaseNotes>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -39,7 +38,6 @@
     
     <ItemGroup>
         <PackageReference Include="Polyfill" PrivateAssets="all"/>
-        <PackageReference Include="DotExtensions" />
        <PackageReference Include="EnhancedLinq" />
         <PackageReference Include="Microsoft.Extensions.Primitives" />
 	</ItemGroup>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -3,7 +3,6 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="DotExtensions" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Polyfill" Version="10.4.0" />

--- a/tests/WCountLib.Testing/TestData/EscapeCharactersTestData.cs
+++ b/tests/WCountLib.Testing/TestData/EscapeCharactersTestData.cs
@@ -1,12 +1,15 @@
-﻿using DotExtensions.Strings;
-
-namespace WCountLib.Testing.TestData;
+﻿namespace WCountLib.Testing.TestData;
 
 public class EscapeCharactersTestData : IEnumerable<string>
 {
+    private static readonly string[] EscapeCharacters = [
+        "\a", "\b", "\f", "\n", "\r", "\t", "\v",
+        "\\", "\0", "\'", "\""
+    ];
+
     public IEnumerator<string> GetEnumerator()
     {
-        foreach (string s in CharacterConstants.EscapeCharacters)
+        foreach (string s in EscapeCharacters)
         {
             yield return s;
         }

--- a/tests/WCountLib.Testing/WCountLib.Testing.csproj
+++ b/tests/WCountLib.Testing/WCountLib.Testing.csproj
@@ -10,7 +10,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DotExtensions" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit.v3" />
     </ItemGroup>


### PR DESCRIPTION
## Why

The dependency review report identified DotExtensions as a trivial-task removal candidate. This PR eliminates the DotExtensions NuGet dependency entirely, reducing external dependencies and maintenance burden.

## What Changed

**Replacement approach:**
- `char.IsSpecialCharacter()` — was NOT a .NET built-in as the dependency review suggested. Created a local `CharExtensions.IsSpecialCharacter()` extension method using `char.IsPunctuation(c) || char.IsSymbol(c)`, which covers the same character set.
- `ArgumentException.ThrowIfNullOrEmpty(StringSegment)` — changed to `segment.Value` since `StringSegment` doesn't implicitly convert to `string?`.

**Files modified (8):**
- Removed `DotExtensions` PackageReference from `WCountLib.csproj` and `WCountLib.Testing.csproj`
- Removed CPM version entries from both `Directory.Packages.props` files
- Removed `global using DotExtensions.Strings` from `GlobalUsings.cs`
- Removed unused `using DotExtensions.MsExtensions.Exceptions` from `SegmentWordDetector.cs`
- Inlined `CharacterConstants.EscapeCharacters` in `EscapeCharactersTestData.cs`

## Verification

- Clean build succeeds with 0 warnings, 0 errors
- No DotExtensions references remain in the codebase
- Pre-existing CLI test failures (path issues in worktree) are unrelated to these changes

---
*Co-authored-by: GitHub Copilot App using MiMo V2.5*