### PR TITLE
Migrate test projects from xUnit v3 to TUnit

### DIFF
--- a/src/WCountCli/Logic/TextReaderLogic.cs
+++ b/src/WCountCli/Logic/TextReaderLogic.cs
@@ -154,9 +154,7 @@ public class TextReaderLogic : ITextReaderLogic
         bool hasPendingNonNewline = false;
         bool hasCharWasCR = false;
         // Initialise chunk state used across ReadTextChunk calls
-        _isInWord = false;
-        _hasPendingNonNewline = false;
-        _currentEncoding = (reader is StreamReader sr) ? sr.CurrentEncoding : ResolveDefaultEncoding();
+        Encoding? currentEncoding = (reader is StreamReader sr) ? sr.CurrentEncoding : ResolveDefaultEncoding();
 
         while ((charsRead = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length), ct)) > 0)
         {
@@ -164,7 +162,7 @@ public class TextReaderLogic : ITextReaderLogic
             {
                 IsInWord = isInWord,
                 HasPendingNonNewline = hasPendingNonNewline,
-                CurrentEncoding = _currentEncoding,
+                CurrentEncoding = currentEncoding,
                 HasCharWasCR = hasCharWasCR
             };
 

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,9 +4,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Polyfill" Version="10.4.0" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="TUnit" Version="1.64.6" />
   </ItemGroup>
 </Project>

--- a/tests/WCountCli.Testing/CliIntegrationTests.cs
+++ b/tests/WCountCli.Testing/CliIntegrationTests.cs
@@ -5,14 +5,14 @@ public sealed class CliIntegrationTests
     private static readonly string BaselinesDir = CliTestRunner.BaselinesDir;
     private static readonly string TestFilesDir = CliTestRunner.TestFilesDir;
 
-    [Theory]
-    [InlineData("-w", "NATURE.txt", "nature_word_count.txt")]
-    [InlineData("-l", "NATURE.txt", "nature_line_count.txt")]
-    [InlineData("-m", "NATURE.txt", "nature_char_count.txt")]
-    [InlineData("-c", "NATURE.txt", "nature_byte_count.txt")]
-    [InlineData("-w -l", "NATURE.txt", "nature_word_line_count.txt")]
-    [InlineData("-w -l -m -c", "NATURE.txt", "nature_all_counts.txt")]
-    [InlineData("", "NATURE.txt", "nature_default.txt")]
+    [Test]
+    [Arguments("-w", "NATURE.txt", "nature_word_count.txt")]
+    [Arguments("-l", "NATURE.txt", "nature_line_count.txt")]
+    [Arguments("-m", "NATURE.txt", "nature_char_count.txt")]
+    [Arguments("-c", "NATURE.txt", "nature_byte_count.txt")]
+    [Arguments("-w -l", "NATURE.txt", "nature_word_line_count.txt")]
+    [Arguments("-w -l -m -c", "NATURE.txt", "nature_all_counts.txt")]
+    [Arguments("", "NATURE.txt", "nature_default.txt")]
     public async Task SingleFile_WithFlags_MatchesBaseline(string flags, string file, string baselineFile)
     {
         var filePath = Path.Combine(TestFilesDir, file);
@@ -21,16 +21,16 @@ public sealed class CliIntegrationTests
         var result = await CliTestRunner.RunAsync(args);
         var expected = await File.ReadAllTextAsync(Path.Combine(BaselinesDir, baselineFile));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(expected, result.Stdout);
-        Assert.Empty(result.Stderr);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Stdout).IsEqualTo(expected);
+        await Assert.That(result.Stderr).IsEmpty();
     }
 
-    [Theory]
-    [InlineData("-l", "CRLF.txt", "crlf_line_count.txt")]
-    [InlineData("", "EMPTY.txt", "empty_default.txt")]
-    [InlineData("-w", "LARGE_WORD.txt", "large_word_count.txt")]
-    [InlineData("-w -l", "WHITESPACE_ONLY.txt", "whitespace_word_line.txt")]
+    [Test]
+    [Arguments("-l", "CRLF.txt", "crlf_line_count.txt")]
+    [Arguments("", "EMPTY.txt", "empty_default.txt")]
+    [Arguments("-w", "LARGE_WORD.txt", "large_word_count.txt")]
+    [Arguments("-w -l", "WHITESPACE_ONLY.txt", "whitespace_word_line.txt")]
     public async Task EdgeCaseFiles_MatchesBaseline(string flags, string file, string baselineFile)
     {
         var filePath = Path.Combine(TestFilesDir, file);
@@ -39,12 +39,12 @@ public sealed class CliIntegrationTests
         var result = await CliTestRunner.RunAsync(args);
         var expected = await File.ReadAllTextAsync(Path.Combine(BaselinesDir, baselineFile));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(expected, result.Stdout);
-        Assert.Empty(result.Stderr);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Stdout).IsEqualTo(expected);
+        await Assert.That(result.Stderr).IsEmpty();
     }
 
-    [Fact]
+    [Test]
     public async Task MultiFile_Total_MatchesBaseline()
     {
         var file1 = Path.Combine(TestFilesDir, "NATURE.txt");
@@ -55,12 +55,12 @@ public sealed class CliIntegrationTests
         var expected = await File.ReadAllTextAsync(
             Path.Combine(BaselinesDir, "multi_file_total.txt"));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(expected, result.Stdout);
-        Assert.Empty(result.Stderr);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Stdout).IsEqualTo(expected);
+        await Assert.That(result.Stderr).IsEmpty();
     }
 
-    [Fact]
+    [Test]
     public async Task Help_ReturnsUsage()
     {
         var args = "-?";
@@ -69,18 +69,18 @@ public sealed class CliIntegrationTests
         var expected = await File.ReadAllTextAsync(
             Path.Combine(BaselinesDir, "help_output.txt"));
 
-        Assert.Equal(0, result.ExitCode);
-        Assert.Equal(expected, result.Stdout);
-        Assert.Empty(result.Stderr);
+        await Assert.That(result.ExitCode).IsEqualTo(0);
+        await Assert.That(result.Stdout).IsEqualTo(expected);
+        await Assert.That(result.Stderr).IsEmpty();
     }
 
-    [Fact]
+    [Test]
     public async Task NonexistentFile_ReturnsError()
     {
         var result = await CliTestRunner.RunAsync("nonexistent_file_xyz.txt");
 
-        Assert.Equal(1, result.ExitCode);
-        Assert.Contains("does not exist", result.Stderr);
-        Assert.Empty(result.Stdout);
+        await Assert.That(result.ExitCode).IsEqualTo(1);
+        await Assert.That(result.Stderr).Contains("does not exist");
+        await Assert.That(result.Stdout).IsEmpty();
     }
 }

--- a/tests/WCountCli.Testing/CliTestRunner.cs
+++ b/tests/WCountCli.Testing/CliTestRunner.cs
@@ -61,7 +61,9 @@ public static class CliTestRunner
         {
             try
             {
-                if (Directory.Exists(Path.Combine(dir.FullName, ".git")))
+                // .git may be a directory (normal repo) or a file (git worktree)
+                var gitPath = Path.Combine(dir.FullName, ".git");
+                if (Directory.Exists(gitPath) || File.Exists(gitPath))
                     return dir.FullName;
             }
             catch

--- a/tests/WCountCli.Testing/GlobalUsings.cs
+++ b/tests/WCountCli.Testing/GlobalUsings.cs
@@ -3,4 +3,5 @@ global using System.Diagnostics;
 global using System.IO;
 global using System.Text;
 global using System.Threading.Tasks;
-global using Xunit;
+global using TUnit;
+global using TUnit.Assertions;

--- a/tests/WCountCli.Testing/WCountCli.Testing.csproj
+++ b/tests/WCountCli.Testing/WCountCli.Testing.csproj
@@ -10,12 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit.v3" />
-        <PackageReference Include="xunit.runner.visualstudio">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="TUnit" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/WCountLib.Testing/Counters/WordCounterTest.cs
+++ b/tests/WCountLib.Testing/Counters/WordCounterTest.cs
@@ -1,5 +1,5 @@
 ﻿using WCountLib.Counters;
-using Xunit;
+using WCountLib.Testing.TestData;
 
 namespace WCountLib.Testing.Counters;
 
@@ -7,21 +7,12 @@ public class WordCounterTest
 {
     private readonly WordCounter _counter = new(new WordDetector());
 
-    [Theory]
-    [ClassData(typeof(RealWordsTestData))]
-    public void CountWords(string words, int expected)
+    [Test]
+    [MethodDataSource<RealWordsTestData>(nameof(RealWordsTestData.GetAllData))]
+    public async Task CountWords(string words, int expected)
     {
         int actual = _counter.CountWords(words);
         
-        Assert.Equal(expected, actual);
+        await Assert.That(actual).IsEqualTo(expected);
     }
-
-    /*[Theory]
-    [ClassData(typeof(FakeWordsTestData))]
-    public void DontCountFakeWords(string words)
-    {
-        int actual = _counter.CountWords(words);
-        
-        Assert.Equal(0, actual);
-    }  */ 
 }

--- a/tests/WCountLib.Testing/GlobalUsings.cs
+++ b/tests/WCountLib.Testing/GlobalUsings.cs
@@ -2,5 +2,8 @@
 
 global using System.Collections;
 global using System.Collections.Generic;
+global using System.Threading.Tasks;
+global using TUnit;
+global using TUnit.Assertions;
 global using WCountLib.Detectors;
 global using WCountLib.Testing.TestData;

--- a/tests/WCountLib.Testing/TestData/EscapeCharactersTestData.cs
+++ b/tests/WCountLib.Testing/TestData/EscapeCharactersTestData.cs
@@ -1,22 +1,17 @@
 ﻿namespace WCountLib.Testing.TestData;
 
-public class EscapeCharactersTestData : IEnumerable<string>
+public static class EscapeCharactersTestData
 {
     private static readonly string[] EscapeCharacters = [
         "\a", "\b", "\f", "\n", "\r", "\t", "\v",
         "\\", "\0", "\'", "\""
     ];
 
-    public IEnumerator<string> GetEnumerator()
+    public static IEnumerable<string> GetAllData()
     {
         foreach (string s in EscapeCharacters)
         {
             yield return s;
         }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
     }
 }

--- a/tests/WCountLib.Testing/TestData/RealWordsTestData.cs
+++ b/tests/WCountLib.Testing/TestData/RealWordsTestData.cs
@@ -2,7 +2,7 @@
 
 namespace WCountLib.Testing.TestData;
 
-public class RealWordsTestData : IEnumerable<object[]>
+public class RealWordsTestData
 {
     private static readonly string[] WordPool =
     [
@@ -19,7 +19,7 @@ public class RealWordsTestData : IEnumerable<object[]>
         "deserunt", "mollit", "anim", "id", "est", "laborum"
     ];
 
-    public IEnumerator<object[]> GetEnumerator()
+    public static IEnumerable<(string Words, int Expected)> GetAllData()
     {
         for (int i = 0; i < 10; i++)
         {
@@ -29,12 +29,7 @@ public class RealWordsTestData : IEnumerable<object[]>
                 picked[j] = WordPool[Random.Shared.Next(WordPool.Length)];
 
             string words = string.Join(' ', picked);
-            yield return new object[] { words, count };
+            yield return (words, count);
         }
-    }
-
-    IEnumerator IEnumerable.GetEnumerator()
-    {
-        return GetEnumerator();
     }
 }

--- a/tests/WCountLib.Testing/WCountLib.Testing.csproj
+++ b/tests/WCountLib.Testing/WCountLib.Testing.csproj
@@ -10,8 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" />
-        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="TUnit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Why

Switch WCount's test suite from xUnit v3 to TUnit 1.64.6 to benefit from compile-time test discovery, faster startup, and Native AOT compatibility.

## What changed

- Replaced `xunit.v3`, `xunit.runner.visualstudio`, and `Microsoft.NET.Test.Sdk` with `TUnit` 1.64.6 (via central package management in `tests/Directory.Packages.props`).
- Converted test attributes: `[Fact]`/`[Theory]` to `[Test]`, `[InlineData]` to `[Arguments]`, and `[ClassData]` to `[MethodDataSource]`.
- Migrated assertions to TUnit's async fluent API (`await Assert.That(x).IsEqualTo/IsEmpty/Contains(...)`).
- Rewrote data providers (`RealWordsTestData`, `EscapeCharactersTestData`) from `IEnumerable<object[]>`/`IEnumerable<string>` to static methods returning tuples or enumerables.
- Updated global usings in both test projects to `TUnit` / `TUnit.Assertions`.

## Pre-existing bugs fixed along the way

These were blocking build/test verification and are included so the migration is verifiable:

- `TextReaderLogic.cs` referenced three undeclared instance fields (`_isInWord`, `_hasPendingNonNewline`, `_currentEncoding`); replaced with a local `currentEncoding` variable the chunk state already used.
- `CliTestRunner.FindRepoRoot()` used `Directory.Exists(".git")`, which fails in git worktrees where `.git` is a file; now also checks `File.Exists`.

## Verification

- `WCountLib.Testing`: builds and 10/10 tests pass.
- `WCountCli.Testing`: builds and 14/14 tests run; they currently fail on baseline comparison because the committed baseline files hardcode the main checkout's absolute paths (e.g. `C:\Users\alast\Documents\GitHub\WCount\...`), which don't match worktree paths. This is a pre-existing test-design flaw unrelated to the framework migration and is left as follow-up.

## Note

Changes were made by GitHub Copilot App (using Hy3).